### PR TITLE
Nutzung von classification.printProcess anstatt objectName

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -105,6 +105,7 @@ exports.createPages = ({ graphql, actions }) => {
               classification {
                 classification
                 condition
+                printProcess
               }
               conditionLevel
               dating {

--- a/src/components/molecules/artefact-line/artefact-line.jsx
+++ b/src/components/molecules/artefact-line/artefact-line.jsx
@@ -41,7 +41,7 @@ export default ({
           <h2 className="artefact-line__title">{title}</h2>
           <h3 className="artefact-line__subtitle">{subtitle}, {date}</h3>
           <ul className="artefact-line__master-data">
-            <li>{masterData.classification.classification}, {masterData.objectName}</li>
+            <li>{masterData.classification.classification}, {masterData.classification.printProcess}</li>
             <li>{masterData.dimensions}</li>
           </ul>
         </Link>

--- a/src/components/organisms/leporello-graphic-details-item/leporello-graphic-details-item.jsx
+++ b/src/components/organisms/leporello-graphic-details-item/leporello-graphic-details-item.jsx
@@ -38,7 +38,6 @@ export default ({
     catalogWorkReferences,
     publications,
     classification,
-    objectName,
   } = graphic;
 
   /* Sorting catalogWorkReferences */
@@ -129,7 +128,7 @@ export default ({
 
               <DefinitionList.Entry
                 term={ t('Classification') }
-                definition={ `${classification.classification}, ${objectName}` }
+                definition={ `${classification.classification}, ${classification.printProcess}` }
               />
               <DefinitionList.Entry
                 term={ t('Dating') }

--- a/src/pages/index.de.jsx
+++ b/src/pages/index.de.jsx
@@ -89,6 +89,7 @@ export const query = graphql`
             classification {
               classification
               condition
+              printProcess
             }
             references {
               reprints {

--- a/src/pages/index.en.jsx
+++ b/src/pages/index.en.jsx
@@ -89,6 +89,7 @@ export const query = graphql`
             classification {
               classification
               condition
+              printProcess
             }
             references {
               reprints {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -89,6 +89,7 @@ export const query = graphql`
             classification {
               classification
               condition
+              printProcess
             }
             references {
               reprints {


### PR DESCRIPTION
Mit diesem PR wird für den Druckvorgang bzw. die Drucktechnologie nicht mehr auf `objectName` zurückgegriffen, sondern auf das neu unter `classification` eingeführte Feld `printProcess`.